### PR TITLE
Use outputFilename with built-in style templates

### DIFF
--- a/src/WebfontPlugin.js
+++ b/src/WebfontPlugin.js
@@ -64,16 +64,16 @@ export default class WebfontPlugin {
                         destStyles = dest;
                     }
 
-                    if (result.usedBuildInStylesTemplate) {
+                    if (this.options.dest.outputFilename) {
+                        destStyles = path.join(
+                            destStyles,
+                            this.options.dest.outputFilename
+                        );
+                    } else if (result.usedBuildInStylesTemplate) {
                         destStyles = path.join(
                             destStyles,
                             `${result.config.fontName}.${result.config
                                 .template}`
-                        );
-                    } else if (this.options.dest.outputFilename) {
-                        destStyles = path.join(
-                            destStyles,
-                            this.options.dest.outputFilename
                         );
                     } else {
                         destStyles = path.join(


### PR DESCRIPTION
When a build-in style template is used, the `outputFilename` is ignored and the filename is generated based on the font name. It should only generate this if a specific `outputFilename` is not set. This allows for generating a SCSS file beginning with an underscore (partial SASS file) using the build-in SCSS template.