### PR TITLE
tests: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ matrix:
       env: JOB_PART=test-only
 
 before_install:
-  - 'if [[ `npm -v` != 5* ]]; then npm i -g npm@^5.0.0; fi'
+  - npm install -g npm@latest
   - nvm --version
   - node --version
   - npm --version
+install:
+  - npm ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ branches:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@latest
-  - npm install
+  - npm ci
 
 test_script:
   - node --version


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable